### PR TITLE
Add --scan option to use scan_iter instead of keys to query

### DIFF
--- a/main.py
+++ b/main.py
@@ -504,7 +504,8 @@ class Main(pytool.cmd.Command):
         self.log.debug(f"Created migration runner.\n"
                        f"prefix = {self.args.prefix}\n"
                        f"workers = {self.args.workers}\n"
-                       f"overwrite = {self.args.overwrite}")
+                       f"overwrite = {self.args.overwrite}\n"
+                       f"scan = ${self.args.scan}")
         migrate.run()
 
 

--- a/main.py
+++ b/main.py
@@ -295,7 +295,7 @@ class Migrate:
         """ Populate the src keys from a thread. """
         timer = pytool.time.Timer()
         self.log.info("Querying source keys.")
-        self.src_keys = self.src.keys(self.prefix)
+        self.src_keys = [x for x in self.src.scan_iter(self.prefix)]
         self.log.info(f"Retrieve source keys: {timer.elapsed}")
         self.log.info(f"Found {len(self.src_keys):,} source keys.")
 
@@ -303,7 +303,7 @@ class Migrate:
         """ Populate the destination keys from a thread. """
         timer = pytool.time.Timer()
         self.log.info("Querying destination keys.")
-        self.dest_keys = self.dest.keys(self.prefix)
+        self.dest_keys = [x for x in self.dest.scan_iter(self.prefix)]
         self.log.info(f"Retrieve destination keys: {timer.elapsed}")
         self.log.info(f"Found {len(self.dest_keys):,} destination keys.")
 

--- a/main.py
+++ b/main.py
@@ -290,7 +290,7 @@ class Migrate:
 
         self.log.info(f"Copy time: {timer.mark()}")
         self.log.info(f"Total time taken: {timer.elapsed}")
-        self.log.info(f"Total keys migraterd: {len(self.keys)}")
+        self.log.info(f"Total keys migrated: {len(self.keys)}")
 
     def get_src_keys(self):
         """ Populate the src keys from a thread. """

--- a/main.py
+++ b/main.py
@@ -481,7 +481,8 @@ class Main(pytool.cmd.Command):
                  help="Do not migrate, delete destination keys")
         self.opt('--logfile', '-f', type=str, help="Log to file")
         self.opt('--prefix', '-p', default="*", help="source key prefix ")
-        self.opt('--scan', action='store_true', help="Use scan() to query keys")
+        self.opt('--scan', action='store_true',
+                 help="Use scan() to query keys")
 
     def run(self):
         self.log = Logger(getattr(logging, self.args.logging.upper()),


### PR DESCRIPTION
Since `keys()` is blocking, using `scan()` will reduce the likelihood that the source falls over while gathering keys.
